### PR TITLE
For later: javascript for timezone test

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,6 +15,7 @@
   <div id="app"></div>
   <script>
     window.$docsify = {
+      executeScript: true,
       homepage: 'home.md',
       name: 'Virtual Science Forum',
       auto2top: true,

--- a/program.md
+++ b/program.md
@@ -1,5 +1,14 @@
 # Program
 
+<script>
+  var loc = Intl.DateTimeFormat().resolvedOptions().timeZone;
+  document.getElementById("location").innerHTML = loc;
+
+  var conferencedate = new Date('2020-03-06T17:00Z');
+  var localtime = conferencedate.getHours();
+  document.getElementById("conferencestart").innerHTML = localtime;
+</script>
+
 The preliminary program and confirmed invited speakers are listed here.
 
 ## Invited speakers
@@ -8,6 +17,8 @@ The preliminary program and confirmed invited speakers are listed here.
 
 
 ## Detailed program
+It seems that you might be browsing from <span id="location">here</span>.
+That means the conference will start at your location at <span id="conferencestart">here</span>.
 
 | PST   	        | EST     	      | CET   	        | Speaker    	|
 |---------------	|---------------	|---------------	|-----------	|


### PR DESCRIPTION
Raw html blocks are valid markdown, so they can be used to set id's for specific sections of a page (I simply used <span>). With executeScript set to true in docsify, the *first* script on every page is parsed, and can hence be used to set document elements by id. 

I haven't yet used the library @akhmerov suggested for timezones; that might be a good idea because the naive approach in here now doesn't take crossing a day into account. 

