### PR TITLE
CSS for registration

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,6 +9,32 @@
   <link rel="stylesheet" href="//cdn.jsdelivr.net/npm/docsify@4.10.2/lib/themes/vue.css">
   <script src="https://cdn.jsdelivr.net/npm/katex-copytex@1.0.2/dist/katex-copytex.min.js"></script>
   <link href="https://cdn.jsdelivr.net/npm/katex-copytex@1.0.2/dist/katex-copytex.min.css" rel="stylesheet" type="text/css">
+  <style>
+
+.meeting_registration {
+	display: flex;
+	width: 100%;
+	height: 100%;
+	flex-direction: column;
+	overflow: hidden;
+}  
+
+div.meeting_registration > iframe {
+	height:1400px;
+	flex-grow: 1;
+	border: none;
+	margin: 0;
+	padding: 0;
+	overflow: hidden;
+}
+
+@media screen and (max-width: 500px){
+	.meeting_registration {display: none;}
+}
+@media screen and (min-width: 500px){
+	.meeting_link {display: none;}
+}
+  </style>
   <title>Virtual Science Forum</title>
 </head>
 <body>

--- a/long_range_colloquium.md
+++ b/long_range_colloquium.md
@@ -26,7 +26,13 @@ Date: 13 May 2020
 
 Spin-triplet superconductivity is a condensate of electron pairs with spin-1 and an odd-parity wavefunction. A particularly interesting manifestation of triplet pairing is a chiral p-wave state which is topologically non-trivial and a natural platform for realizing Majorana edge modes. Triplet pairing is however rare in solid state systems. The best-known example of chiral spin-triplet paring is the superfluid 3He-A phase and over the last few decades, there has been an intensive search for potential spin-triplet superconductors in solid-state systems. Since pairing is most naturally mediated by ferromagnetic spin fluctuations, uranium based heavy fermion systems containing f-electron elements that can harbor both strong correlations and magnetism are considered ideal candidate spin-triplet superconductors. In this work I will present scanning tunneling microscopy (STM) data on the newly discovered heavy fermion superconductor, $\textrm{UTe}_2$ with a $T_{\textrm{SC}}$ of 1.6K. I will show signatures of coexisting Kondo effect and superconductivity which show competing spatial modulations within one unit-cell.  STM spectroscopy at step edges show signatures of chiral in-gap states, predicted to exist at the boundaries of a topological superconductor. Combined with existing data indicating triplet pairing, the presence of chiral edge states suggests that UTe2 is a strong candidate material for chiral-triplet topological superconductivity.
 
-<iframe src="https://iu.zoom.us/meeting/register/tJYtdeGqqDwjHd0jLB_K5sBbPVl7MMLqb-wP" width="700" height="910" frameborder="0" marginheight="0" marginwidth="0" style="overflow-x:hidden" scrolling=no>Loading…</iframe>
+<div class="meeting_registration">
+<iframe src="https://iu.zoom.us/meeting/register/tJYtdeGqqDwjHd0jLB_K5sBbPVl7MMLqb-wP" scrolling="no">Loading...</iframe>
+</div>
+<div class="meeting_link">
+<a href="https://iu.zoom.us/meeting/register/tJYtdeGqqDwjHd0jLB_K5sBbPVl7MMLqb-wP">Register</a>
+</div>
+
 
 ### Nicola Spaldin, ETH Zürich
 


### PR DESCRIPTION
I modified the CSS pertaining the registration form. A new css class media_registration is introduced that can be applied to a div. It modifies the behaviour of the div (and the iframe below it) so that the iframe and its contents also behaves in a responsive way (i.e. the registration form goes from two to one-column). In addition, two CSS media queries are added that hide the iframe and offer a link to the registration form if the screen width goes below 500px.

The two changes are fairly independent, i.e. removing the @media instructions in index.html will disable the hiding of the iframe/showing the link instead while the registration_form class in the CSS govern the sizing and behaviour of the iframe. I chose the height of 1400px for the iframe within the meeting_registration div is chosen "heuristically", so that the whole page is shown including footer etc.