### PR TITLE
Update organizerguide.md

### DIFF
--- a/organizerguide.md
+++ b/organizerguide.md
@@ -1,28 +1,29 @@
 # Organizer Guide
 
-So, you are thinking of organizing a short virtual conference session. This is easy, rewarding, and takes little work. This manual will guide you through the process.
+So, you are thinking of organizing a short virtual event. This is easy, rewarding, and takes little work. This manual will guide you through the process.
 
 #### Bird’s eye view of what it takes
 Here is a short summary of all the steps you will need to take
 
-- Make a team of organizers
+- Build a team of organizers
 - Decide on a recent and exciting topic
-- Write a brief description of the session
-- Decide on the scale/format of the session: number of speakers and length of talks
-- Make a list of possible author groups to approach
-- Decide on a date that suits your timeline (should be at least 2 months in the future, so that you can find the speakers and announce the session properly)
+- Write a brief description of the event
+- Decide on the scale/format of the event: length; number of talks; whether to have only invited talks or also contributed talks; whether to have a poster session...
+- Make a list of possible speakers to approach
+- Decide on a date (should be at least 2 months in the future, so that you can find the speakers and announce the event properly)
 - Submit an application to us
-- After the time slot is reserved, approach the speakers, make a program
-- Find the moderators for the talks, ensure that the moderators and the speakers try the software in advance
+- Approach the speakers, invite submissions for the contributed talks (if you have them) and start making a program
+- Find the moderators for the talks
 - Advertise the event
-- Approve participant applications for registration.
-- Run the session
-- Summarize your experience
+- Build a webpage / create a registration and if applicable abstract submission form.
+- Email the Zoom link to the registered participants one or two days before the event
+- Test the software with the moderators and speakers the day before the event
+- Run the event and have fun!
 
 #### Basic facts
 
 - We support sessions of up to 3 hours in a single day (longer sessions have problems with retention).
-- There is essentially one time slot that suits America and Europe: 12:00–15:00 EST.
+- One timeslot can suit only two timezones: America/Europe, Europe/Asia or Asia/America. You can use [this website](https://www.timeanddate.com/worldclock/meeting.html) to find the timeslot that best suits your needs. 
 - Both conventional conference talks of up to one hour (including questions), and 10-15 minute talks work well.
 - We require that all the videos are recorded and published on the website after the session.
 
@@ -32,19 +33,19 @@ Apply via a github issue [here](https://github.com/virtualscienceforum/virtualsc
 
 ## Detailed instructions
 
-### Planning and application: two months before the session
+### Planning and application: two months before the event
 
-Choose the organizer team of 2-4 people. Since you will be inviting the speakers and the audience, your team should have good connections in the community. It is also a good idea to find organizers from more than one research group/university.
+Build an organizer team of 2--4 people. Since you will be inviting the speakers and the audience, your team should have good connections in the community. It is also a good idea to find organizers from more than one research group/university.
 
 Decide on the topic of the session. We strongly recommend to focus on recent developments: these make it easier to attract an audience, and you benefit from a shorter waiting period until the conference.
 
-Choose a session name. Write a brief explanation of what the topic is, and why it is important. These will eventually go on the session webpage, so try and make them clean and attractive. If possible, prepare a poster-like image to go along with the description.
+Choose a name for your event. Write a brief explanation of what the topic is, and why it is important. This will eventually go on the event's webpage, so try and make it clean and attractive. If possible, prepare an image to go along with the description.
 
-Make a list of prospective speakers that you plan to approach. Since the virtual conferences are experimental in nature, we recommend approaching groups of authors instead of single researchers. This also gives an extra opportunity for less senior researchers to present exciting work.
+Make a list of prospective speakers that you plan to approach. 
 
-Choose a date and time slot that suits your session. Try to avoid conflicts with conferences on related topics, major holidays, etc.
+Choose a date and time slot for your event. Try to avoid conflicts with conferences on related topics, major holidays, etc.
 
-Finally, submit the materials that you collected to the VSF. At this stage we aim to accept all applications after basic review (unless the demand is overwhelming).
+Finally, submit this information to the VSF. At this stage we aim to accept all applications after basic review (unless the demand is overwhelming).
 
 ### Reaching out to speakers: at least 6 weeks before the session
 


### PR DESCRIPTION
Hi @babaks77, 

In general, I suggest to keep the wording broad. The first event was a conference session, but new organizers might have in mind a workshop or a seminar instead, so 'event' should cover it all.

At some point any event will need to appear on a web page with a registration form, and this should go in the instructions. It could say for example 'publish the information about the event in a dedicated page of the VSF's website. The VSF can help with the creation of the forms for registration and abstract submission'.  Is this the idea?

Will events be run from the VSF (that is, yours) Zoom account? If yes it would be a useful detail to add. The point could be 'no need to worry about the online platform, the event can be run using the VSF Zoom account'. 

'Summarize your experience' makes sense only if we ask organizers to prepare some kind of report in the end, otherwise it can be left implicit that they can wrap up their thoughts in a blog post or on their website if they wish.

I would have a separate point for testing the software -- please edit to reflect what is actually being done (test the day before? Test 10 minutes before the event?)

So far speakers have been quite willing to present at virtual events, so I would remove the part that says 'approach groups of authors instead of individual authors'. We might say something about ensuring a good gender, geographical and seniority balance instead if we wish. Or we leave it up to the organizers?

I will look at the rest of the document later.

I'm still not sure if this is the best way of making changes and adding comments -- as a test I'm creating a pull request and see what happens :)