### PR TITLE
summer --> winter

### DIFF
--- a/home.md
+++ b/home.md
@@ -6,7 +6,7 @@ Additionally we develop best practices and provide recommendations for all commu
 
 ## What we do
 
-We offer beginning-to-end support for organizing an academic event of your own, check out the [organizer guide](organizerguide.md) to see what it takes. It could be a seminar series, a workshop or a tutorial. Now that summer has arrived, we particularly encourage applications for summer schools organized by graduate students, post docs or early-career researchers. 
+We offer beginning-to-end support for organizing an academic event of your own, check out the [organizer guide](organizerguide.md) to see what it takes. It could be a seminar series, a workshop or a tutorial. Now that winter has arrived, we particularly encourage applications for winter schools organized by graduate students, post docs or early-career researchers. 
 
 ### Current Events
 * [Long Range Colloquium](long_range_colloquium.md) series **every other Wednesday** at 1:30 pm EDT / 7:30pm CEST


### PR DESCRIPTION
We had text related to summer and summer schools, which is clearly outdated. I'm suggesting an update to "winter", but we can also delete the sentence if we'd like.