### PR TITLE
Replace special chars in title

### DIFF
--- a/bots/render_talks.py
+++ b/bots/render_talks.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 from datetime import datetime
 import re
+import string
 
 import jinja2
 import pytz
@@ -10,13 +11,15 @@ yaml = YAML(typ='safe')
 with open('../talks.yml') as f:
     talks = yaml.load(f)
 
-def replace_specials(str):
-    return re.sub('[^a-zA-Z0-9\n\.]', '', str)
-
+def format_title(s):
+    punctuation = string.punctuation.replace('-','')
+    s = s.translate(str.maketrans('', '', punctuation))
+    return s.replace(' ', '-')
+    
 env = jinja2.Environment(
     loader=jinja2.FileSystemLoader('../templates')
 )
-env.filters['replace_specials'] = replace_specials
+env.filters['format_title'] = format_title
 
 header = Path("../speakers-corner-header.md").read_text()
 

--- a/bots/render_talks.py
+++ b/bots/render_talks.py
@@ -10,9 +10,13 @@ yaml = YAML(typ='safe')
 with open('../talks.yml') as f:
     talks = yaml.load(f)
 
+def replace_specials(str):
+    return re.sub('[^a-zA-Z0-9\n\.]', '', str)
+
 env = jinja2.Environment(
     loader=jinja2.FileSystemLoader('../templates')
 )
+env.filters['replace_specials'] = replace_specials
 
 header = Path("../speakers-corner-header.md").read_text()
 

--- a/bots/render_talks.py
+++ b/bots/render_talks.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 from datetime import datetime
 import re
-import string
+from string import punctuation
 
 import jinja2
 import pytz
@@ -11,11 +11,11 @@ yaml = YAML(typ='safe')
 with open('../talks.yml') as f:
     talks = yaml.load(f)
 
+punctuation_without_dash = punctuation.replace('-','')
+translation_table = str.maketrans('','', punctuation_without_dash)
 def format_title(s):
-    punctuation = string.punctuation.replace('-','')
-    s = s.translate(str.maketrans('', '', punctuation))
-    return s.replace(' ', '-')
-    
+    return s.translate(translation_table).replace(' ', '-')
+
 env = jinja2.Environment(
     loader=jinja2.FileSystemLoader('../templates')
 )

--- a/templates/long_range_colloquium.md.j2
+++ b/templates/long_range_colloquium.md.j2
@@ -13,7 +13,7 @@ Attendance is open to everyone, but please register to attend! If you would like
 |   Date   |     Speaker    | Title |
 |:---------:|:--------------:|:-----:|
 {%- for talk in talks | sort(attribute="time") if talk.time > now %}
-| {{ talk.time.strftime("%B %-d") }} | {{ talk.speaker_name }} | [{{ talk.title }}](#{{ talk.title | replace_specials | lower }}) |
+| {{ talk.time.strftime("%B %-d") }} | {{ talk.speaker_name }} | [{{ talk.title }}](#{{ talk.title | lower | format_title }}) |
 {%- endfor %}
 
 ## Upcoming talks

--- a/templates/long_range_colloquium.md.j2
+++ b/templates/long_range_colloquium.md.j2
@@ -5,7 +5,7 @@
 The Long Range Colloquium is a bi-weekly seminar series covering the latest developments in condensed matter physics and quantum information. We alternate experimental and theory talks to keep the schedule exciting for a varied audience: have a look at our 2021 schedule below!
 You can also find all the information and recordings for our 2020 talks [here](https://virtualscienceforum.org/#/long_range_colloquium-2020).
 
-The colloquium runs every other Wednesday at 1:30 PM ET / 19:30 CEST. 
+The colloquium runs every other Wednesday at 1:30 PM ET / 19:30 CEST.
 Attendance is open to everyone, but please register to attend! If you would like to hear about upcoming talks, you can subscribe to the colloquim mailing list [here](https://virtualscienceforum.org/#/mailinglist).
 
 ## Program
@@ -13,7 +13,7 @@ Attendance is open to everyone, but please register to attend! If you would like
 |   Date   |     Speaker    | Title |
 |:---------:|:--------------:|:-----:|
 {%- for talk in talks | sort(attribute="time") if talk.time > now %}
-| {{ talk.time.strftime("%B %-d") }} | {{ talk.speaker_name }} | [{{ talk.title }}](#{{ talk.title.replace(" ", "-") | lower }}) |
+| {{ talk.time.strftime("%B %-d") }} | {{ talk.speaker_name }} | [{{ talk.title }}](#{{ talk.title | replace_specials | lower }}) |
 {%- endfor %}
 
 ## Upcoming talks
@@ -44,7 +44,7 @@ If the form below doesn't work, [register directly]({{ talk.registration_url }})
 
 {{talk.abstract}}
 
-Authors: {{ talk.authors }}  
+Authors: {{ talk.authors }}
 Preprint: [arXiv:{{ talk.arxiv }}](https://arxiv.org/abs/{{ talk.arxiv }})
 </details>
 

--- a/templates/speakers_corner.md.j2
+++ b/templates/speakers_corner.md.j2
@@ -10,7 +10,7 @@ All times are shown in <span id="timezone">UTC</span> timezone.
 |   Date   |     Speaker    | Title |
 |:---------:|:--------------:|:-----:|
 {%- for talk in upcoming | sort(attribute="time") %}
-| <time datetime="{{ talk.time.isoformat() }}">{{ talk.time.strftime("%B %-d %-H:%M %Z") }}</time> | {{ talk.speaker_name }} | [{{ talk.title }}](#{{ talk.title.replace(" ", "-").replace(":", "") | lower }}) |
+| <time datetime="{{ talk.time.isoformat() }}">{{ talk.time.strftime("%B %-d %-H:%M %Z") }}</time> | {{ talk.speaker_name }} | [{{ talk.title }}](#{{ talk.title | lower | format_title }}) |
 {%- endfor %}
 
 ## Upcoming talks
@@ -23,7 +23,7 @@ All times are shown in <span id="timezone">UTC</span> timezone.
 > {{ line }}
 {%- endfor %}
 >
-> **Authors:** {{ talk.authors }}  
+> **Authors:** {{ talk.authors }}
 {% if talk.preprint %}> **Preprint:** [arXiv:{{ talk.preprint }}](https://arxiv.org/abs/{{ talk.preprint }}){% endif %}
 
 {% if talk.registration_url %}
@@ -56,7 +56,7 @@ There are no upcoming talks at the moment, apply [here](https://github.com/virtu
 
 {{talk.abstract}}
 
-Authors: {{ talk.authors }}  
+Authors: {{ talk.authors }}
 Preprint: [arXiv:{{ talk.arxiv }}](https://arxiv.org/abs/{{ talk.arxiv }})
 </details>
 

--- a/templates/speakers_corner.md.j2
+++ b/templates/speakers_corner.md.j2
@@ -23,7 +23,7 @@ All times are shown in <span id="timezone">UTC</span> timezone.
 > {{ line }}
 {%- endfor %}
 >
-> **Authors:** {{ talk.authors }}
+> **Authors:** {{ talk.authors }}  
 {% if talk.preprint %}> **Preprint:** [arXiv:{{ talk.preprint }}](https://arxiv.org/abs/{{ talk.preprint }}){% endif %}
 
 {% if talk.registration_url %}
@@ -56,7 +56,7 @@ There are no upcoming talks at the moment, apply [here](https://github.com/virtu
 
 {{talk.abstract}}
 
-Authors: {{ talk.authors }}
+Authors: {{ talk.authors }}  
 Preprint: [arXiv:{{ talk.arxiv }}](https://arxiv.org/abs/{{ talk.arxiv }})
 </details>
 

--- a/whoweare.md
+++ b/whoweare.md
@@ -15,7 +15,7 @@ Virtual Science Forum is a collaborative effort of the research community. Below
 
 ## Past contributors:
 * Xavi Bonet, Leiden University
-* Stefan Bretzel
+* Stefan Bretzel, LANconcept Moll GmbH
 * Sinead Griffin, Lawrence Berkeley National Lab
 * Adolfo Grushin, Institut Néel
 * Akashdeep Kamra, NTNU Trondheim

--- a/whoweare.md
+++ b/whoweare.md
@@ -2,15 +2,21 @@
 
 Virtual Science Forum is a collaborative effort of the research community. Below is the list of contributors so far (in the alphabetical order)!
 
+## Current contributors: 
+
 * Anton Akhmerov, TU Delft
-* Xavi Bonet, Leiden University
 * Valla Fatemi, Yale University
-* Eliska Greplova, ETH Zürich
+* Eliska Greplova, TU Delft
+* Evert van Nieuwenburg, Niels Bohr Institute
+* Giulia Pacchioni, Springer Nature
+* Babak Seradjeh, Indiana University
+* Alberto de la Torre, Brown University
+
+
+## Past contributors:
+* Xavi Bonet, Leiden University
 * Sinead Griffin, Lawrence Berkeley National Lab
 * Adolfo Grushin, Institut Néel
 * Akashdeep Kamra, NTNU Trondheim
 * Maciej Malinowski, ETH Zürich
-* Evert van Nieuwenburg, Niels Bohr Institute
-* Giulia Pacchioni, Springer Nature
-* Babak Seradjeh, Indiana University
 * Daniel Varjas, TU Delft

--- a/whoweare.md
+++ b/whoweare.md
@@ -15,6 +15,7 @@ Virtual Science Forum is a collaborative effort of the research community. Below
 
 ## Past contributors:
 * Xavi Bonet, Leiden University
+* Stefan Bretzel
 * Sinead Griffin, Lawrence Berkeley National Lab
 * Adolfo Grushin, Institut Néel
 * Akashdeep Kamra, NTNU Trondheim


### PR DESCRIPTION
Interpratation of how markdown does it [here](https://github.com/gjtorikian/html-pipeline/blob/main/lib/html/pipeline/toc_filter.rb), by 

1. Converting to lower
2. Removing all punctuation except for '-'
3. Replace whitespace with '-'

I don't check for uniqueness, since two identical titles is going to be extremely rare