### PR TITLE
add two satellite talks to Superdiodes workshop

### DIFF
--- a/src/josephson-diode.md
+++ b/src/josephson-diode.md
@@ -73,7 +73,18 @@ Then you may either:
 
 We will include the satellite talks in this workshop webpage.
 
+### Submitted Satellite Talks
 
+* May 10 10:00 ET - Bomin Zhang (University of Pittsburgh) <br/>
+  Superconducting diode effect in InSb nanowires Josephson junctions <br/>
+  [Speakers' Corner link](https://virtualscienceforum.org/speakers-corner/#superconducting-diode-effect-in-insb-nanowires-josephson-junctions)
+*  May 11 10:00 ET - Stefan Ilić (Centro de Fisica de Materiales (CFM-MPC), San Sebastian, Spain) <br/>
+  Theory of the supercurrent diode effect in Rashba superconductors with arbitrary disorder <br/>
+  Preprint: [arXiv:2108.00209](https://arxiv.org/abs/2108.00209) <br/>
+  [Speakers' Corner link](https://virtualscienceforum.org/speakers-corner/#theory-of-the-supercurrent-diode-effect-in-rashba-superconductors-with-arbitrary-disorder)
+
+  
+  
 ## Organizers
 
 * [Mazhar N. Ali, TU Delft](https://www.linkedin.com/in/profmaz/)

--- a/src/josephson-diode.md
+++ b/src/josephson-diode.md
@@ -75,10 +75,10 @@ We will include the satellite talks in this workshop webpage.
 
 ### Submitted Satellite Talks
 
-* May 10 10:00 ET - Bomin Zhang (University of Pittsburgh) <br/>
+* <time data-format="H:mm" datetime="2022-05-10T14:00:00+00:00">May 10 14:00</time> - Bomin Zhang (University of Pittsburgh) <br/>
   Superconducting diode effect in InSb nanowires Josephson junctions <br/>
   [Speakers' Corner link](https://virtualscienceforum.org/speakers-corner/#superconducting-diode-effect-in-insb-nanowires-josephson-junctions)
-*  May 11 10:00 ET - Stefan Ilić (Centro de Fisica de Materiales (CFM-MPC), San Sebastian, Spain) <br/>
+* <time data-format="H:mm" datetime="2022-05-11T14:00:00+00:00">May 11 14:00</time> - Stefan Ilić (Centro de Fisica de Materiales (CFM-MPC), San Sebastian, Spain) <br/>
   Theory of the supercurrent diode effect in Rashba superconductors with arbitrary disorder <br/>
   Preprint: [arXiv:2108.00209](https://arxiv.org/abs/2108.00209) <br/>
   [Speakers' Corner link](https://virtualscienceforum.org/speakers-corner/#theory-of-the-supercurrent-diode-effect-in-rashba-superconductors-with-arbitrary-disorder)

--- a/src/josephson-diode.md
+++ b/src/josephson-diode.md
@@ -75,10 +75,10 @@ We will include the satellite talks in this workshop webpage.
 
 ### Submitted Satellite Talks
 
-* <time data-format="H:mm" datetime="2022-05-10T14:00:00+00:00">May 10 14:00</time> - Bomin Zhang (University of Pittsburgh) <br/>
+* <time data-format="MMMM D H:mm" datetime="2022-05-10T14:00:00+00:00">May 10 14:00</time> - Bomin Zhang (University of Pittsburgh) <br/>
   Superconducting diode effect in InSb nanowires Josephson junctions <br/>
   [Speakers' Corner link](https://virtualscienceforum.org/speakers-corner/#superconducting-diode-effect-in-insb-nanowires-josephson-junctions)
-* <time data-format="H:mm" datetime="2022-05-11T14:00:00+00:00">May 11 14:00</time> - Stefan Ilić (Centro de Fisica de Materiales (CFM-MPC), San Sebastian, Spain) <br/>
+* <time data-format="MMMM D H:mm" datetime="2022-05-11T14:00:00+00:00">May 11 14:00</time> - Stefan Ilić (Centro de Fisica de Materiales (CFM-MPC), San Sebastian, Spain) <br/>
   Theory of the supercurrent diode effect in Rashba superconductors with arbitrary disorder <br/>
   Preprint: [arXiv:2108.00209](https://arxiv.org/abs/2108.00209) <br/>
   [Speakers' Corner link](https://virtualscienceforum.org/speakers-corner/#theory-of-the-supercurrent-diode-effect-in-rashba-superconductors-with-arbitrary-disorder)


### PR DESCRIPTION
I didn't include the registration directly in the workshop page to minimize space occupation but could try to add it if we feel it is important. 